### PR TITLE
Modbus coils start at 0th bit tcp (IDFGH-10998)

### DIFF
--- a/freemodbus/serial_master/modbus_controller/mbc_serial_master.c
+++ b/freemodbus/serial_master/modbus_controller/mbc_serial_master.c
@@ -567,7 +567,7 @@ eMBErrorCode eMBRegCoilsCBSerialMaster(UCHAR* pucRegBuffer, USHORT usAddress,
         switch (eMode) {
             case MB_REG_WRITE:
                 while (usCoils > 0) {
-                    UCHAR ucResult = xMBUtilGetBits((UCHAR*)pucRegCoilsBuf, iRegIndex, 1);
+                    UCHAR ucResult = xMBUtilGetBits((UCHAR*)pucRegCoilsBuf, iRegIndex - (usAddress % 8), 1);
                     xMBUtilSetBits(pucRegBuffer, iRegIndex - (usAddress % 8) , 1, ucResult);
                     iRegIndex++;
                     usCoils--;
@@ -576,7 +576,7 @@ eMBErrorCode eMBRegCoilsCBSerialMaster(UCHAR* pucRegBuffer, USHORT usAddress,
             case MB_REG_READ:
                 while (usCoils > 0) {
                     UCHAR ucResult = xMBUtilGetBits(pucRegBuffer, iRegIndex - (usAddress % 8), 1);
-                    xMBUtilSetBits((uint8_t*)pucRegCoilsBuf, iRegIndex, 1, ucResult);
+                    xMBUtilSetBits((uint8_t*)pucRegCoilsBuf, iRegIndex - (usAddress % 8), 1, ucResult);
                     iRegIndex++;
                     usCoils--;
                 }
@@ -622,7 +622,7 @@ eMBErrorCode eMBRegDiscreteCBSerialMaster(UCHAR * pucRegBuffer, USHORT usAddress
         iRegBitIndex = (USHORT)(usAddress) % 8; // Get bit index
         while (iNReg > 1)
         {
-            xMBUtilSetBits(pucDiscreteInputBuf++, iRegBitIndex, 8, *pucRegBuffer++);
+            xMBUtilSetBits(pucDiscreteInputBuf++, iRegBitIndex - ((USHORT)(usAddress) % 8), 8, *pucRegBuffer++);
             iNReg--;
         }
         // last discrete
@@ -630,7 +630,7 @@ eMBErrorCode eMBRegDiscreteCBSerialMaster(UCHAR * pucRegBuffer, USHORT usAddress
         // xMBUtilSetBits has bug when ucNBits is zero
         if (usNDiscrete != 0)
         {
-            xMBUtilSetBits(pucDiscreteInputBuf, iRegBitIndex, usNDiscrete, *pucRegBuffer++);
+            xMBUtilSetBits(pucDiscreteInputBuf, iRegBitIndex - ((USHORT)(usAddress) % 8), usNDiscrete, *pucRegBuffer++);
         }
     } else {
         eStatus = MB_ENOREG;

--- a/freemodbus/tcp_master/modbus_controller/mbc_tcp_master.c
+++ b/freemodbus/tcp_master/modbus_controller/mbc_tcp_master.c
@@ -680,7 +680,7 @@ eMBErrorCode eMBRegCoilsCBTcpMaster(UCHAR *pucRegBuffer, USHORT usAddress,
         switch (eMode) {
             case MB_REG_WRITE:
                 while (usCoils > 0) {
-                    UCHAR ucResult = xMBUtilGetBits((UCHAR*)pucRegCoilsBuf, iRegIndex, 1);
+                    UCHAR ucResult = xMBUtilGetBits((UCHAR*)pucRegCoilsBuf, iRegIndex - (usAddress % 8), 1);
                     xMBUtilSetBits(pucRegBuffer, iRegIndex - (usAddress % 8) , 1, ucResult);
                     iRegIndex++;
                     usCoils--;
@@ -689,7 +689,7 @@ eMBErrorCode eMBRegCoilsCBTcpMaster(UCHAR *pucRegBuffer, USHORT usAddress,
             case MB_REG_READ:
                 while (usCoils > 0) {
                     UCHAR ucResult = xMBUtilGetBits(pucRegBuffer, iRegIndex - (usAddress % 8), 1);
-                    xMBUtilSetBits((uint8_t*)pucRegCoilsBuf, iRegIndex, 1, ucResult);
+                    xMBUtilSetBits((uint8_t*)pucRegCoilsBuf, iRegIndex - (usAddress % 8), 1, ucResult);
                     iRegIndex++;
                     usCoils--;
                 }
@@ -733,7 +733,7 @@ eMBErrorCode eMBRegDiscreteCBTcpMaster(UCHAR * pucRegBuffer, USHORT usAddress,
         iRegBitIndex = (USHORT)(usAddress) % 8; // Get bit index
         while (iNReg > 1)
         {
-            xMBUtilSetBits(pucDiscreteInputBuf++, iRegBitIndex, 8, *pucRegBuffer++);
+            xMBUtilSetBits(pucDiscreteInputBuf++, iRegBitIndex - ((USHORT)(usAddress) % 8), 8, *pucRegBuffer++);
             iNReg--;
         }
         // last discrete
@@ -741,7 +741,7 @@ eMBErrorCode eMBRegDiscreteCBTcpMaster(UCHAR * pucRegBuffer, USHORT usAddress,
         // xMBUtilSetBits has bug when ucNBits is zero
         if (usNDiscrete != 0)
         {
-            xMBUtilSetBits(pucDiscreteInputBuf, iRegBitIndex, usNDiscrete, *pucRegBuffer++);
+            xMBUtilSetBits(pucDiscreteInputBuf, iRegBitIndex - ((USHORT)(usAddress) % 8), usNDiscrete, *pucRegBuffer++);
         }
     } else {
         eStatus = MB_ENOREG;


### PR DESCRIPTION
Coils/discrete transactions (read/write) seem to align everything to %8, so they work correctly only for start address being n*8. This is not specified in the standard. Affects both RTU and TCP. 