### PR TITLE
feature/add user error handler

### DIFF
--- a/docs/en/master_api_overview.rst
+++ b/docs/en/master_api_overview.rst
@@ -433,7 +433,9 @@ The function writes characteristic's value defined as a name and cid parameter i
             ESP_LOGE(TAG, "Set data fail, err = 0x%x (%s).", (int)err, (char*)esp_err_to_name(err));
         }
 
-The above functions propagate the status of the transaction as a return error code. This return code does not clarify some information such as slave exception code returned in the response. In this case the below function can be useful.
+# Extra error information
+
+In case the does not clarify some information, such as slave exception code returned in the response, the functions below can be useful.
 
 :cpp:func:`mbc_master_get_transaction_info`
 
@@ -507,7 +509,7 @@ Below is the way to expose the transaction info and request/response buffers def
 
 The user handler function can be useful to check the Modbus frame buffers and expose some information right before returning from the call :cpp:func:`mbc_master_set_parameter` or :cpp:func:`mbc_master_get_parameter` functions.
 
-.. note:: The above handler function may prevent the Modbus FSM to work properly! The body of the handler needs to be as short as possible and contain just simple functionality that will not block processing for relatively long time. This is user software responcibility to not break the Modbus functionality using the function.
+.. warning:: The above handler function may prevent the Modbus FSM to work properly! The body of the handler needs to be as short as possible and contain just simple functionality that will not block processing for relatively long time. This is user software responcibility to not break the Modbus functionality using the function.
 
 .. _modbus_api_master_destroy:
 

--- a/freemodbus/common/esp_modbus_master.c
+++ b/freemodbus/common/esp_modbus_master.c
@@ -180,7 +180,7 @@ esp_err_t mbc_master_start(void)
 }
 
 eMBErrorCode eMBMasterRegDiscreteCB(UCHAR * pucRegBuffer, USHORT usAddress,
-                            USHORT usNDiscrete)
+                                        USHORT usNDiscrete)
 {
     eMBErrorCode error = MB_ENOERR;
     MB_MASTER_CHECK((master_interface_ptr != NULL),
@@ -194,7 +194,7 @@ eMBErrorCode eMBMasterRegDiscreteCB(UCHAR * pucRegBuffer, USHORT usAddress,
 }
 
 eMBErrorCode eMBMasterRegCoilsCB(UCHAR* pucRegBuffer, USHORT usAddress,
-        USHORT usNCoils, eMBRegisterMode eMode)
+                                    USHORT usNCoils, eMBRegisterMode eMode)
 {
     eMBErrorCode error = MB_ENOERR;
     MB_MASTER_CHECK((master_interface_ptr != NULL),
@@ -209,7 +209,7 @@ eMBErrorCode eMBMasterRegCoilsCB(UCHAR* pucRegBuffer, USHORT usAddress,
 }
 
 eMBErrorCode eMBMasterRegHoldingCB(UCHAR * pucRegBuffer, USHORT usAddress,
-        USHORT usNRegs, eMBRegisterMode eMode)
+                                    USHORT usNRegs, eMBRegisterMode eMode)
 {
     eMBErrorCode error = MB_ENOERR;
     MB_MASTER_CHECK((master_interface_ptr != NULL),
@@ -224,7 +224,7 @@ eMBErrorCode eMBMasterRegHoldingCB(UCHAR * pucRegBuffer, USHORT usAddress,
 }
 
 eMBErrorCode eMBMasterRegInputCB(UCHAR * pucRegBuffer, USHORT usAddress,
-                                USHORT usNRegs)
+                                    USHORT usNRegs)
 {
     eMBErrorCode error = MB_ENOERR;
     MB_MASTER_CHECK((master_interface_ptr != NULL),
@@ -242,16 +242,14 @@ eMBErrorCode eMBMasterRegInputCB(UCHAR * pucRegBuffer, USHORT usAddress,
  */
 esp_err_t mbc_master_get_transaction_info(mb_trans_info_t *ptinfo)
 {
-    mb_trans_info_t tinfo = {0};
     MB_MASTER_CHECK((ptinfo),
                     ESP_ERR_INVALID_ARG,
                     "Wrong argument.");
-    MB_MASTER_CHECK(xMBMasterGetLastTransactionInfo(&tinfo.trans_id, &tinfo.dest_addr,
-                                                    &tinfo.func_code, &tinfo.exception,
-                                                    &tinfo.err_type),
+    MB_MASTER_CHECK(xMBMasterGetLastTransactionInfo(&ptinfo->trans_id, &ptinfo->dest_addr,
+                                                    &ptinfo->func_code, &ptinfo->exception,
+                                                    &ptinfo->err_type),
                     ESP_ERR_INVALID_STATE,
                     "Master can not get transaction info.");
-    *ptinfo = tinfo;
     return ESP_OK;
 }
 

--- a/freemodbus/common/esp_modbus_master.c
+++ b/freemodbus/common/esp_modbus_master.c
@@ -237,6 +237,24 @@ eMBErrorCode eMBMasterRegInputCB(UCHAR * pucRegBuffer, USHORT usAddress,
     return error;
 }
 
+/**
+ * Helper function to get current transaction info
+ */
+esp_err_t mbc_master_get_transaction_info(mb_trans_info_t *ptinfo)
+{
+    mb_trans_info_t tinfo = {0};
+    MB_MASTER_CHECK((ptinfo),
+                    ESP_ERR_INVALID_ARG,
+                    "Wrong argument.");
+    MB_MASTER_CHECK(xMBMasterGetLastTransactionInfo(&tinfo.trans_id, &tinfo.dest_addr,
+                                                    &tinfo.func_code, &tinfo.exception,
+                                                    &tinfo.err_type),
+                    ESP_ERR_INVALID_STATE,
+                    "Master can not get transaction info.");
+    *ptinfo = tinfo;
+    return ESP_OK;
+}
+
 // Helper function to set parameter buffer according to its type
 esp_err_t mbc_master_set_param_data(void* dest, void* src, mb_descr_type_t param_type, size_t param_size)
 {

--- a/freemodbus/common/include/esp_modbus_master.h
+++ b/freemodbus/common/include/esp_modbus_master.h
@@ -151,6 +151,17 @@ typedef struct {
 } mb_param_request_t;
 
 /**
+ * @brief Modbus transacion info structure
+ */
+typedef struct {
+    uint64_t trans_id;              /*!< Modbus unique transaction identificator */
+    uint8_t dest_addr;              /*!< Modbus destination short address (or UID) */
+    uint8_t func_code;              /*!< Modbus last transaction function code */
+    uint8_t exception;              /*!< Modbus last transaction exception code returned by slave */
+    uint16_t err_type;              /*!< Modbus last transaction error type */
+} mb_trans_info_t;
+
+/**
  * @brief Initialize Modbus controller and stack for TCP port
  *
  * @param[out] handler handler(pointer) to master data structure
@@ -320,6 +331,18 @@ esp_err_t mbc_master_set_parameter(uint16_t cid, char* name, uint8_t* value, uin
  *     - esp_err_t ESP_ERR_NOT_SUPPORTED - the request command is not supported by slave
 */
 esp_err_t mbc_master_set_param_data(void* dest, void* src, mb_descr_type_t param_type, size_t param_size);
+
+/**
+ * @brief The helper function to expose transaction info from modbus layer
+ *
+ * @param[in] ptinfo the pointer to transaction info structure
+ *
+ * @return
+ *     - esp_err_t ESP_OK - the transaction info is saved in the appropriate parameter structure
+ *     - esp_err_t ESP_ERR_INVALID_ARG - invalid argument of function or parameter descriptor
+ *     - esp_err_t ESP_ERR_INVALID_STATE - invalid state during data processing or allocation failure
+*/
+esp_err_t mbc_master_get_transaction_info(mb_trans_info_t *ptinfo);
 
 #ifdef __cplusplus
 }

--- a/freemodbus/common/include/esp_modbus_master.h
+++ b/freemodbus/common/include/esp_modbus_master.h
@@ -155,10 +155,10 @@ typedef struct {
  */
 typedef struct {
     uint64_t trans_id;              /*!< Modbus unique transaction identificator */
+    uint16_t err_type;              /*!< Modbus last transaction error type */
     uint8_t dest_addr;              /*!< Modbus destination short address (or UID) */
     uint8_t func_code;              /*!< Modbus last transaction function code */
     uint8_t exception;              /*!< Modbus last transaction exception code returned by slave */
-    uint16_t err_type;              /*!< Modbus last transaction error type */
 } mb_trans_info_t;
 
 /**

--- a/freemodbus/common/mbc_master.h
+++ b/freemodbus/common/mbc_master.h
@@ -18,6 +18,7 @@
 #include "esp_modbus_common.h"      // for common types
 #include "esp_modbus_master.h"      // for public master types
 #include "esp_modbus_callbacks.h"
+#include "mb_m.h"                   // this is required to expose current transaction info
 
 /* ----------------------- Defines ------------------------------------------*/
 

--- a/freemodbus/modbus/ascii/mbascii_m.c
+++ b/freemodbus/modbus/ascii/mbascii_m.c
@@ -83,7 +83,6 @@ typedef enum
 /* These Modbus values are shared in ASCII mode*/
 extern volatile UCHAR   ucMasterRcvBuf[];
 extern volatile UCHAR   ucMasterSndBuf[];
-extern volatile eMBMasterTimerMode eMasterCurTimerMode;
 
 /* ----------------------- Static functions ---------------------------------*/
 static UCHAR    prvucMBCHAR2BIN( UCHAR ucCharacter );

--- a/freemodbus/modbus/include/mb_m.h
+++ b/freemodbus/modbus/include/mb_m.h
@@ -105,6 +105,12 @@ typedef enum
     MB_TMODE_CONVERT_DELAY          /*!< Master sent broadcast ,then delay sometime.*/
 } eMBMasterTimerMode;
 
+extern _lock_t xMBMLock; // Modbus lock object
+
+#define MB_ATOMIC_SECTION() CRITICAL_SECTION(xMBMLock)
+#define MB_ATOMIC_STORE(PTR, DES) CRITICAL_STORE(xMBMLock, PTR, DES)
+#define MB_ATOMIC_LOAD(PTR) CRITICAL_LOAD(xMBMLock, PTR)
+
 /* ----------------------- Function prototypes ------------------------------*/
 /*! \ingroup modbus
  * \brief Initialize the Modbus Master protocol stack.

--- a/freemodbus/modbus/include/mb_m.h
+++ b/freemodbus/modbus/include/mb_m.h
@@ -95,6 +95,19 @@ typedef enum
     MB_MRE_EXE_FUN                  /*!< execute function error. */
 } eMBMasterReqErrCode;
 
+
+/*! \ingroup modbus
+ * \brief Transaction information structure.
+ */
+typedef struct
+{
+    uint64_t xTransId;
+    UCHAR ucDestAddr;
+    UCHAR ucFuncCode;
+    eMBException eException;
+    UCHAR ucFrameError;
+} TransactionInfo_t;
+
 /*! \ingroup modbus
  *  \brief TimerMode is Master 3 kind of Timer modes.
  */
@@ -107,9 +120,7 @@ typedef enum
 
 extern _lock_t xMBMLock; // Modbus lock object
 
-#define MB_ATOMIC_SECTION() CRITICAL_SECTION(xMBMLock)
-#define MB_ATOMIC_STORE(PTR, DES) CRITICAL_STORE(xMBMLock, PTR, DES)
-#define MB_ATOMIC_LOAD(PTR) CRITICAL_LOAD(xMBMLock, PTR)
+#define MB_ATOMIC_SECTION CRITICAL_SECTION(xMBMLock)
 
 /* ----------------------- Function prototypes ------------------------------*/
 /*! \ingroup modbus

--- a/freemodbus/modbus/include/mb_m.h
+++ b/freemodbus/modbus/include/mb_m.h
@@ -100,9 +100,9 @@ typedef enum
  */
 typedef enum
 {
-	MB_TMODE_T35,                   /*!< Master receive frame T3.5 timeout. */
-	MB_TMODE_RESPOND_TIMEOUT,       /*!< Master wait respond for slave. */
-	MB_TMODE_CONVERT_DELAY          /*!< Master sent broadcast ,then delay sometime.*/
+    MB_TMODE_T35,                   /*!< Master receive frame T3.5 timeout. */
+    MB_TMODE_RESPOND_TIMEOUT,       /*!< Master wait respond for slave. */
+    MB_TMODE_CONVERT_DELAY          /*!< Master sent broadcast ,then delay sometime.*/
 } eMBMasterTimerMode;
 
 /* ----------------------- Function prototypes ------------------------------*/
@@ -128,7 +128,7 @@ typedef enum
  *    - eMBErrorCode::MB_EPORTERR IF the porting layer returned an error.
  */
 eMBErrorCode    eMBMasterSerialInit( eMBMode eMode, UCHAR ucPort,
-		                 ULONG ulBaudRate, eMBParity eParity );
+                                        ULONG ulBaudRate, eMBParity eParity );
 
 /*! \ingroup modbus
  * \brief Initialize the Modbus Master protocol stack for Modbus TCP.
@@ -220,7 +220,7 @@ eMBErrorCode    eMBMasterPoll( void );
  *   valid it returns eMBErrorCode::MB_EINVAL.
  */
 eMBErrorCode    eMBMasterRegisterCB( UCHAR ucFunctionCode,
-                               pxMBFunctionHandler pxHandler );
+                                        pxMBFunctionHandler pxHandler );
 
 /* ----------------------- Callback -----------------------------------------*/
 
@@ -261,7 +261,7 @@ eMBErrorCode    eMBMasterRegisterCB( UCHAR ucFunctionCode,
  *       <b>ILLEGAL DATA ADDRESS</b> is sent as a response.
  */
 eMBErrorCode eMBMasterRegInputCB( UCHAR * pucRegBuffer, USHORT usAddress,
-		USHORT usNRegs );
+                                        USHORT usNRegs );
 
 /*! \ingroup modbus_registers
  * \brief Callback function used if a <em>Holding Register</em> value is
@@ -290,7 +290,7 @@ eMBErrorCode eMBMasterRegInputCB( UCHAR * pucRegBuffer, USHORT usAddress,
  *       <b>ILLEGAL DATA ADDRESS</b> is sent as a response.
  */
 eMBErrorCode eMBMasterRegHoldingCB( UCHAR * pucRegBuffer, USHORT usAddress,
-		USHORT usNRegs, eMBRegisterMode eMode );
+                                        USHORT usNRegs, eMBRegisterMode eMode );
 
 /*! \ingroup modbus_registers
  * \brief Callback function used if a <em>Coil Register</em> value is
@@ -319,7 +319,7 @@ eMBErrorCode eMBMasterRegHoldingCB( UCHAR * pucRegBuffer, USHORT usAddress,
  *       <b>ILLEGAL DATA ADDRESS</b> is sent as a response.
  */
 eMBErrorCode eMBMasterRegCoilsCB( UCHAR * pucRegBuffer, USHORT usAddress,
-		USHORT usNCoils, eMBRegisterMode eMode );
+                                        USHORT usNCoils, eMBRegisterMode eMode );
 
 /*! \ingroup modbus_registers
  * \brief Callback function used if a <em>Input Discrete Register</em> value is
@@ -342,7 +342,7 @@ eMBErrorCode eMBMasterRegCoilsCB( UCHAR * pucRegBuffer, USHORT usAddress,
  *       <b>ILLEGAL DATA ADDRESS</b> is sent as a response.
  */
 eMBErrorCode eMBMasterRegDiscreteCB( UCHAR * pucRegBuffer, USHORT usAddress,
-		USHORT usNDiscrete );
+                                        USHORT usNDiscrete );
 
 /*! \ingroup modbus
  *\brief These Modbus functions are called for user when Modbus run in Master Mode.
@@ -353,20 +353,20 @@ eMBMasterReqErrCode
 eMBMasterReqWriteHoldingRegister( UCHAR ucSndAddr, USHORT usRegAddr, USHORT usRegData, LONG lTimeOut );
 eMBMasterReqErrCode
 eMBMasterReqWriteMultipleHoldingRegister( UCHAR ucSndAddr, USHORT usRegAddr,
-		USHORT usNRegs, USHORT * pusDataBuffer, LONG lTimeOut );
+        USHORT usNRegs, USHORT * pusDataBuffer, LONG lTimeOut );
 eMBMasterReqErrCode
 eMBMasterReqReadHoldingRegister( UCHAR ucSndAddr, USHORT usRegAddr, USHORT usNRegs, LONG lTimeOut );
 eMBMasterReqErrCode
 eMBMasterReqReadWriteMultipleHoldingRegister( UCHAR ucSndAddr,
-		USHORT usReadRegAddr, USHORT usNReadRegs, USHORT * pusDataBuffer,
-		USHORT usWriteRegAddr, USHORT usNWriteRegs, LONG lTimeOut );
+        USHORT usReadRegAddr, USHORT usNReadRegs, USHORT * pusDataBuffer,
+        USHORT usWriteRegAddr, USHORT usNWriteRegs, LONG lTimeOut );
 eMBMasterReqErrCode
 eMBMasterReqReadCoils( UCHAR ucSndAddr, USHORT usCoilAddr, USHORT usNCoils, LONG lTimeOut );
 eMBMasterReqErrCode
 eMBMasterReqWriteCoil( UCHAR ucSndAddr, USHORT usCoilAddr, USHORT usCoilData, LONG lTimeOut );
 eMBMasterReqErrCode
 eMBMasterReqWriteMultipleCoils( UCHAR ucSndAddr,
-		USHORT usCoilAddr, USHORT usNCoils, UCHAR * pucDataBuffer, LONG lTimeOut );
+        USHORT usCoilAddr, USHORT usNCoils, UCHAR * pucDataBuffer, LONG lTimeOut );
 eMBMasterReqErrCode
 eMBMasterReqReadDiscreteInputs( UCHAR ucSndAddr, USHORT usDiscreteAddr, USHORT usNDiscreteIn, LONG lTimeOut );
 
@@ -409,6 +409,9 @@ eMBMasterErrorEventType eMBMasterGetErrorType( void );
 void vMBMasterSetErrorType( eMBMasterErrorEventType errorType );
 eMBMasterReqErrCode eMBMasterWaitRequestFinish( void );
 eMBMode ucMBMasterGetCommMode( void );
+BOOL xMBMasterGetLastTransactionInfo( uint64_t *pxTransId, UCHAR *pucDestAddress,
+                                        UCHAR *pucFunctionCode, UCHAR *pucException,
+                                        USHORT *pusErrorType );
 
 /* ----------------------- Callback -----------------------------------------*/
 

--- a/freemodbus/modbus/include/mbport.h
+++ b/freemodbus/modbus/include/mbport.h
@@ -40,6 +40,7 @@
 
 #include "mbconfig.h"   // for options
 
+
 #ifdef __cplusplus
 PR_BEGIN_EXTERN_C
 #endif
@@ -92,10 +93,10 @@ typedef enum {
 } eMBMasterErrorEventType;
 
 typedef struct _MbEventType {
-    eMBMasterEventEnum eEvent;      /*!< event itself. */
-    uint64_t xTransactionId;        /*!< ID of the transaction */
-    uint64_t xPostTimestamp;        /*!< timestamp of event posted */
-    uint64_t xGetTimestamp;         /*!< timestamp of event get */
+    eMBMasterEventEnum eEvent;          /*!< event itself. */
+    uint64_t xTransactionId;            /*!< ID of the transaction */
+    uint64_t xPostTimestamp;            /*!< timestamp of event posted */
+    uint64_t xGetTimestamp;             /*!< timestamp of event get */
 } xMBMasterEventType;
 
 #endif

--- a/freemodbus/modbus/include/mbport.h
+++ b/freemodbus/modbus/include/mbport.h
@@ -95,7 +95,7 @@ typedef struct _MbEventType {
     eMBMasterEventEnum eEvent;      /*!< event itself. */
     uint64_t xTransactionId;        /*!< ID of the transaction */
     uint64_t xPostTimestamp;        /*!< timestamp of event posted */
-    uint64_t xGetTimestamp;         /*!< timestamp of event get */ 
+    uint64_t xGetTimestamp;         /*!< timestamp of event get */
 } xMBMasterEventType;
 
 #endif

--- a/freemodbus/modbus/include/mbport.h
+++ b/freemodbus/modbus/include/mbport.h
@@ -207,16 +207,20 @@ void            vMBMasterPortTimersDisable( void );
 
 
 /* ----------------- Callback for the master error process ------------------*/
-void            vMBMasterErrorCBRespondTimeout( UCHAR ucDestAddress, const UCHAR* pucPDUData,
-                                                USHORT ucPDULength );
+void            vMBMasterErrorCBRespondTimeout( uint64_t xTransId, UCHAR ucDestAddress,
+                                                const UCHAR* pucSendData, USHORT ucSendLength );
 
-void            vMBMasterErrorCBReceiveData( UCHAR ucDestAddress, const UCHAR* pucPDUData,
-                                             USHORT ucPDULength );
+void            vMBMasterErrorCBReceiveData( uint64_t xTransId, UCHAR ucDestAddress, 
+                                                const UCHAR* pucRecvData, USHORT ucRecvLength,
+                                                const UCHAR* pucSendData, USHORT ucSendLength );
 
-void            vMBMasterErrorCBExecuteFunction( UCHAR ucDestAddress, const UCHAR* pucPDUData,
-                                                 USHORT ucPDULength );
+void            vMBMasterErrorCBExecuteFunction( uint64_t xTransId, UCHAR ucDestAddress, 
+                                                    const UCHAR* pucRecvData, USHORT ucRecvLength,
+                                                    const UCHAR* pucSendData, USHORT ucSendLength );
 
-void            vMBMasterCBRequestSuccess( void );
+void            vMBMasterCBRequestSuccess( uint64_t xTransId, UCHAR ucDestAddress,
+                                            const UCHAR* pucRecvData, USHORT ucRecvLength,
+                                            const UCHAR* pucSendData, USHORT ucSendLength );
 #endif
 /* ----------------------- Callback for the protocol stack ------------------*/
 /*!

--- a/freemodbus/modbus/mb_m.c
+++ b/freemodbus/modbus/mb_m.c
@@ -272,7 +272,7 @@ eMBMasterSerialInit( eMBMode eMode, UCHAR ucPort, ULONG ulBaudRate, eMBParity eP
             atomic_init(&usMasterSendPDULength, 0);
             atomic_init(&eMBMasterCurErrorType, EV_ERROR_INIT);
             atomic_init(&xMBRunInMasterMode, FALSE);
-            atomic_init(&ucMBMasterDestAddress, MB_TCP_PSEUDO_ADDRESS);
+            atomic_init(&ucMBMasterDestAddress, 0);
         }
         /* initialize the OS resource for modbus master. */
         vMBMasterOsResInit();
@@ -514,7 +514,7 @@ eMBMasterPoll( void )
                 ESP_LOGD( MB_PORT_TAG, "Transaction (%" PRIu64 "), processing time(us) = %" PRId64, xCurTransactionId, xProcTime );
                 MB_ATOMIC_SECTION {
                     xTransactionInfo.xTransId = xCurTransactionId;
-                    xTransactionInfo.ucDestAddr = atomic_load(&ucMBMasterDestAddress);
+                    xTransactionInfo.ucDestAddr = ucMBMasterGetDestAddress();
                     xTransactionInfo.ucFuncCode = ucFunctionCode;
                     xTransactionInfo.eException = eException;
                     xTransactionInfo.ucFrameError = errorType;

--- a/freemodbus/port/port.c
+++ b/freemodbus/port/port.c
@@ -39,7 +39,6 @@
 /* ----------------------- Modbus includes ----------------------------------*/
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
-#include "sys/lock.h"
 #include "port.h"
 
 /* ----------------------- Variables ----------------------------------------*/
@@ -47,13 +46,24 @@ static _lock_t s_port_lock;
 static UCHAR ucPortMode = 0;
 
 /* ----------------------- Start implementation -----------------------------*/
-inline void
+INLINE int lock_obj(_lock_t *plock)
+{
+    _lock_acquire(plock);
+    return 1;
+}
+
+INLINE void unlock_obj(_lock_t *plock)
+{
+    _lock_release(plock);
+}
+
+INLINE void
 vMBPortEnterCritical(void)
 {
     _lock_acquire(&s_port_lock);
 }
 
-inline void
+INLINE void
 vMBPortExitCritical(void)
 {
     _lock_release(&s_port_lock);

--- a/freemodbus/port/port.h
+++ b/freemodbus/port/port.h
@@ -154,28 +154,6 @@ void unlock_obj(_lock_t *plock);
 
 #define CRITICAL_SECTION(lock) for (int st = lock_obj((_lock_t *)&lock); (st > 0); unlock_obj((_lock_t *)&lock), st = -1)
 
-#define CRITICAL_STORE(LOCK, PTR, DES) \
-__extension__ \
-({  \
-    __auto_type __atomic_ptr = (PTR); \
-    __typeof__ ((void)0, *__atomic_ptr) __atomic_tmp = (DES); \
-    lock_obj((_lock_t *)&LOCK); \
-    *__atomic_ptr = __atomic_tmp; \
-    unlock_obj((_lock_t *)&LOCK); \
-    (__atomic_tmp); \
-})
-
-#define CRITICAL_LOAD(LOCK, PTR) \
-__extension__ \
-({  \
-    __auto_type __atomic_ptr = (PTR); \
-    __typeof__ ((void)0, *__atomic_ptr) __atomic_tmp; \
-    lock_obj((_lock_t *)&LOCK); \
-    __atomic_tmp = (*__atomic_ptr); \
-    unlock_obj((_lock_t *)&LOCK); \
-    (__atomic_tmp); \
-})
-
 #ifdef __cplusplus
 PR_BEGIN_EXTERN_C
 #endif /* __cplusplus */

--- a/freemodbus/port/port.h
+++ b/freemodbus/port/port.h
@@ -215,7 +215,7 @@ BOOL xMBPortSerialWaitEvent(QueueHandle_t xMbUartQueue, uart_event_t* pxEvent, U
  */
 MB_ATTR_WEAK
 void vMBMasterErrorCBUserHandler( uint64_t xTransId, USHORT usError, UCHAR ucDestAddress, const UCHAR* pucRecvData, USHORT ucRecvLength,
-                                                        const UCHAR* pucSendData, USHORT ucSendLength );
+                                    const UCHAR* pucSendData, USHORT ucSendLength );
 
 #ifdef __cplusplus
 PR_END_EXTERN_C

--- a/freemodbus/port/port.h
+++ b/freemodbus/port/port.h
@@ -105,6 +105,8 @@
 
 #define MB_TCP_DEBUG                    (LOG_LOCAL_LEVEL >= ESP_LOG_DEBUG) // Enable legacy debug output in TCP module.
 
+#define MB_ATTR_WEAK                    __attribute__ ((weak))
+
 #define MB_TCP_GET_FIELD(buffer, field) ((USHORT)((buffer[field] << 8U) | buffer[field + 1]))
 
 #define MB_PORT_CHECK(a, ret_val, str, ...) \
@@ -197,6 +199,23 @@ void vMBPortSetMode( UCHAR ucMode );
 UCHAR ucMBPortGetMode( void );
 
 BOOL xMBPortSerialWaitEvent(QueueHandle_t xMbUartQueue, uart_event_t* pxEvent, ULONG xTimeout);
+
+/**
+ * This is modbus master user error handling funcion.
+ * If it is defined in the user application, then helps to handle the errors
+ * and received/sent buffers to transfer as well as handle the slave exception codes.
+ * 
+ * @param xTransId - the identification of the trasaction
+ * @param ucDestAddress destination salve address
+ * @param usError - the error code, see the enumeration eMBMasterErrorEventType
+ * @param pucRecvData current receive data pointer
+ * @param ucRecvLength current length of receive buffer
+ * @param pucSendData Send buffer data
+ * @param ucSendLength Send buffer length
+ */
+MB_ATTR_WEAK
+void vMBMasterErrorCBUserHandler( uint64_t xTransId, USHORT usError, UCHAR ucDestAddress, const UCHAR* pucRecvData, USHORT ucRecvLength,
+                                                        const UCHAR* pucSendData, USHORT ucSendLength );
 
 #ifdef __cplusplus
 PR_END_EXTERN_C

--- a/freemodbus/port/portevent_m.c
+++ b/freemodbus/port/portevent_m.c
@@ -191,30 +191,47 @@ void vMBMasterRunResRelease( void )
  * This is modbus master respond timeout error process callback function.
  * @note There functions will block modbus master poll while execute OS waiting.
  *
+ * @param xTransId - the identification of the trasaction
  * @param ucDestAddress destination salve address
- * @param pucPDUData PDU buffer data
- * @param ucPDULength PDU buffer length
+ * @param pucRecvData current receive data pointer
+ * @param ucRecvLength current length of receive buffer
+ * @param pucSendData Send buffer data
+ * @param ucSendLength Send buffer length
  *
  */
-void vMBMasterErrorCBRespondTimeout(UCHAR ucDestAddress, const UCHAR* pucPDUData, USHORT ucPDULength)
+void vMBMasterErrorCBRespondTimeout(uint64_t xTransId, UCHAR ucDestAddress, const UCHAR* pucSendData, USHORT ucSendLength)
 {
     (void)xEventGroupSetBits( xEventGroupMasterHdl, EV_MASTER_ERROR_RESPOND_TIMEOUT );
     ESP_LOGD(MB_PORT_TAG,"%s:Callback respond timeout.", __func__);
+    if (vMBMasterErrorCBUserHandler) {
+        vMBMasterErrorCBUserHandler( xTransId, (USHORT)EV_ERROR_RESPOND_TIMEOUT, 
+                                        ucDestAddress, NULL, 0,
+                                        pucSendData, ucSendLength );
+    }
 }
 
 /**
  * This is modbus master receive data error process callback function.
  * @note There functions will block modbus master poll while execute OS waiting.
  *
+ * @param xTransId - the identification of the trasaction
  * @param ucDestAddress destination salve address
- * @param pucPDUData PDU buffer data
- * @param ucPDULength PDU buffer length
+ * @param pucRecvData current receive data pointer
+ * @param ucRecvLength current length of receive buffer
+ * @param pucSendData Send buffer data
+ * @param ucSendLength Send buffer length
  */
-void vMBMasterErrorCBReceiveData(UCHAR ucDestAddress, const UCHAR* pucPDUData, USHORT ucPDULength)
+void vMBMasterErrorCBReceiveData(uint64_t xTransId, UCHAR ucDestAddress, 
+                                    const UCHAR* pucRecvData, USHORT ucRecvLength, 
+                                    const UCHAR* pucSendData, USHORT ucSendLength)
 {
     (void)xEventGroupSetBits( xEventGroupMasterHdl, EV_MASTER_ERROR_RECEIVE_DATA );
-    ESP_LOGD(MB_PORT_TAG,"%s:Callback receive data timeout failure.", __func__);
-    ESP_LOG_BUFFER_HEX_LEVEL("Err rcv buf", (void *)pucPDUData, (USHORT)ucPDULength, ESP_LOG_DEBUG);
+    ESP_LOGD(MB_PORT_TAG,"%s:Callback receive data failure.", __func__);
+    if (vMBMasterErrorCBUserHandler) {
+        vMBMasterErrorCBUserHandler( xTransId, (USHORT)EV_ERROR_RECEIVE_DATA,
+                                    ucDestAddress, pucRecvData, ucRecvLength,
+                                    pucSendData, ucSendLength );
+    }
 }
 
 /**
@@ -222,27 +239,50 @@ void vMBMasterErrorCBReceiveData(UCHAR ucDestAddress, const UCHAR* pucPDUData, U
  * @note There functions will block modbus master poll while execute OS waiting.
  * So,for real-time of system.Do not execute too much waiting process.
  *
+ * @param xTransId - the identification of the trasaction
  * @param ucDestAddress destination salve address
- * @param pucPDUData PDU buffer data
- * @param ucPDULength PDU buffer length
+ * @param pucRecvData current receive data pointer
+ * @param ucRecvLength current length of receive buffer
+ * @param pucSendData Send buffer data
+ * @param ucSendLength Send buffer length
  *
  */
-void vMBMasterErrorCBExecuteFunction(UCHAR ucDestAddress, const UCHAR* pucPDUData, USHORT ucPDULength)
+void vMBMasterErrorCBExecuteFunction(uint64_t xTransId, UCHAR ucDestAddress,
+                                        const UCHAR* pucRecvData, USHORT ucRecvLength,
+                                        const UCHAR* pucSendData, USHORT ucSendLength)
 {
     xEventGroupSetBits( xEventGroupMasterHdl, EV_MASTER_ERROR_EXECUTE_FUNCTION );
     ESP_LOGD(MB_PORT_TAG,"%s:Callback execute data handler failure.", __func__);
-    ESP_LOG_BUFFER_HEX_LEVEL("Exec func buf", (void*)pucPDUData, (USHORT)ucPDULength, ESP_LOG_DEBUG);
+    if (vMBMasterErrorCBUserHandler) {
+        vMBMasterErrorCBUserHandler( xTransId, (USHORT)EV_ERROR_EXECUTE_FUNCTION,
+                                        ucDestAddress, pucRecvData, ucRecvLength,
+                                        pucSendData, ucSendLength );
+    }
 }
 
 /**
  * This is modbus master request process success callback function.
  * @note There functions will block modbus master poll while execute OS waiting.
  * So,for real-time of system. Do not execute too much waiting process.
+ * 
+ * @param xTransId - the identification of the trasaction
+ * @param ucDestAddress destination salve address
+ * @param pucRecvData current receive data pointer
+ * @param ucRecvLength current length of receive buffer
+ * @param pucSendData Send buffer data
+ * @param ucSendLength Send buffer length
  */
-void vMBMasterCBRequestSuccess( void ) 
+void vMBMasterCBRequestSuccess(uint64_t xTransId, UCHAR ucDestAddress,
+                                        const UCHAR* pucRecvData, USHORT ucRecvLength,
+                                        const UCHAR* pucSendData, USHORT ucSendLength)
 {
     (void)xEventGroupSetBits( xEventGroupMasterHdl, EV_MASTER_PROCESS_SUCCESS );
     ESP_LOGD(MB_PORT_TAG,"%s: Callback request success.", __func__);
+    if (vMBMasterErrorCBUserHandler) {
+        vMBMasterErrorCBUserHandler( xTransId, (USHORT)EV_ERROR_OK,
+                                        ucDestAddress, pucRecvData, ucRecvLength,
+                                        pucSendData, ucSendLength );
+    }
 }
 
 /**

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -9,3 +9,5 @@ files:
     - "docs"
     - "test/**/*"
     - "test"
+    - "arch"
+    - "arch/**/*"

--- a/test/serial/mb_serial_master/main/CMakeLists.txt
+++ b/test/serial/mb_serial_master/main/CMakeLists.txt
@@ -2,3 +2,4 @@ set(PROJECT_NAME "modbus_master")
 
 idf_component_register(SRCS "master.c"
                         INCLUDE_DIRS ".")
+

--- a/test/serial/mb_serial_master/main/master.c
+++ b/test/serial/mb_serial_master/main/master.c
@@ -483,6 +483,29 @@ static esp_err_t master_init(void)
     return err;
 }
 
+#ifndef UCHAR
+#define UCHAR uint8_t
+#define USHORT uint16_t
+#define MB_PDU_DATA_OFF 1
+#endif
+
+#define EV_ERROR_EXECUTE_FUNCTION 3
+
+void vMBMasterErrorCBUserHandler( uint64_t xTransId, USHORT usError, UCHAR ucDestAddress, const UCHAR* pucRecvData, USHORT ucRecvLength,
+                                                        const UCHAR* pucSendData, USHORT ucSendLength )
+{
+    ESP_LOGW("USER_ERR_CB", "The transaction error type: %u", usError);
+    if ((usError == EV_ERROR_EXECUTE_FUNCTION) && pucRecvData && ucRecvLength) {
+        ESP_LOGW("USER_ERR_CB", "The command is unsupported or an exception on slave happened: %x", (int)pucRecvData[1]);
+    }
+    if (pucRecvData && ucRecvLength) {
+        ESP_LOG_BUFFER_HEX_LEVEL("Received buffer", (void *)pucRecvData, (USHORT)ucRecvLength, ESP_LOG_WARN);
+    }
+    if (pucSendData && ucSendLength) {
+        ESP_LOG_BUFFER_HEX_LEVEL("Sent buffer", (void *)pucSendData, (USHORT)ucSendLength, ESP_LOG_WARN);
+    }
+}
+
 void app_main(void)
 {
     // Initialization of device peripheral and objects


### PR DESCRIPTION
This PR adds the user error handler. This handler is called on packet processing error and allows to catch the request/response buffers for the corresponded Modbus transaction.

This PR addresses the issue: https://github.com/espressif/esp-modbus/issues/60