### PR TITLE
Removed extra closing braces to avoid C++ compiler error (IDFGH-13419)

### DIFF
--- a/modbus/mb_objects/include/mb_config.h
+++ b/modbus/mb_objects/include/mb_config.h
@@ -160,9 +160,7 @@ extern "C" {
 #define MB_FUNC_READWRITE_HOLDING_ENABLED       (1)
 
 /*! @} */
-#ifdef __cplusplus
-}
-#endif
+
 
 #if MB_MASTER_RTU_ENABLED || MB_MASTER_ASCII_ENABLED || MB_MASTER_TCP_ENABLED
 /*! \brief If master send a broadcast frame, the master will wait time of convert to delay,


### PR DESCRIPTION
When using the library with C++ code the build process fails due to an extra closing brace. This PR removes this brace.