### PR TITLE
fix: flush uart queue on parity and frame error (IDFGH-13881)

### DIFF
--- a/freemodbus/port/portserial.c
+++ b/freemodbus/port/portserial.c
@@ -161,10 +161,14 @@ static void vUartTask(void *pvParameters)
                 //Event of UART parity check error
                 case UART_PARITY_ERR:
                     ESP_LOGD(TAG, "uart parity error");
+                    xQueueReset(xMbUartQueue);
+                    uart_flush_input(ucUartNumber);
                     break;
                 //Event of UART frame error
                 case UART_FRAME_ERR:
                     ESP_LOGD(TAG, "uart frame error");
+                    xQueueReset(xMbUartQueue);
+                    uart_flush_input(ucUartNumber);
                     break;
                 default:
                     ESP_LOGD(TAG, "uart event type: %u", (unsigned)xEvent.type);


### PR DESCRIPTION
## Description
In the current version (V1.0.16), UART parity and frame errors are ignored for the Modbus slave.
This bugfix branch addresses the issue by flushing the UART queue when an error occurs.

Please consider merging this branch into the next release.

## Related
The same issue has already been resolved for the Modbus master.
For reference: https://github.com/espressif/esp-modbus/issues/20

## Testing
The bugfix was tested by sending UART frames containing errors.