### PR TITLE
fix slave tcp skips requests from multiple masters

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -33,7 +33,20 @@ menu "Modbus configuration"
         help
                 Modbus TCP connection timeout in seconds.
                 Once expired the current connection with the client will be closed
-                and Modbus slave will be waiting for new connection to accept.
+                and Modbus TCP slave will be waiting for new connection to accept.
+                This timeout is applicable for Modbus TCP master when it tries to connect to the Modbus TCP slaves.
+    
+    config FMB_TCP_KEEP_ALIVE_TOUT_SEC
+        int "Modbus TCP keep alive timeout (seconds)"
+        default 4
+        range 1 7200
+        depends on FMB_COMM_MODE_TCP_EN
+        help
+                This option is used to set keep-alive time for Modbus TCP connections.
+                This timeout is the interval after which the device sends keep-alive messages
+                to maintain a connection with a server before register the error.
+                The keep-alive time can be configured and should be set based on the actual needs of the application,
+                considering the trade-off between keeping the connection alive and minimizing system load.
 
     config FMB_TCP_UID_ENABLED
         bool "Modbus TCP enable UID (Unit Identifier) support"
@@ -72,12 +85,12 @@ menu "Modbus configuration"
                 then master can send next frame.
 
     config FMB_QUEUE_LENGTH
-        int "Modbus serial task queue length"
-        range 0 200
-        default 20
+        int "Modbus event task queue length"
+        range 10 500
+        default 50
         help
-                Modbus serial driver queue length. It is used by event queue task.
-                See the serial driver API for more information.
+                Modbus event queue length. It is used by event queue tasks
+                for corresponding communication mode.
 
     config FMB_PORT_TASK_STACK_SIZE
         int "Modbus port task stack size"

--- a/docs/en/master_api_overview.rst
+++ b/docs/en/master_api_overview.rst
@@ -571,6 +571,8 @@ The example to retrieve the slave identificator from slave:
         ESP_LOG_BUFFER_HEX_LEVEL("SLAVE_INFO", (void*)info_buf, sizeof(info_buf), ESP_LOG_WARN);
     }
 
+.. note:: Please refer to :ref:`modbus_master_slave_configuration_aspects` for proper configuration.
+
 .. _modbus_api_master_destroy:
 
 Modbus Master Teardown

--- a/docs/en/port_initialization.rst
+++ b/docs/en/port_initialization.rst
@@ -111,8 +111,6 @@ The format of slave definition following the notation `UID;slave_host_ip_or_dns_
 The slave IP addresses of the slaves can be resolved automatically by the stack using mDNS service as described in the example. In this case each slave has to use the mDNS service support and define its host name appropriately.
 Refer to :ref:`example TCP master <example_mb_tcp_master>`, :ref:`example TCP slave <example_mb_tcp_slave>` for more information.
 
-.. note:: The Modbus Master TCP functionality is under testing and competition status will be announced later over official channels.
-
 .. _modbus_api_slave_setup_communication_options:
 
 Slave Communication Options
@@ -168,5 +166,3 @@ This example code to initialize Modbus TCP slave:
     }
 
 .. note:: Refer to `esp_netif component <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_netif.html>`__ for more information about network interface initialization.
-
-.. note:: The Modbus Slave TCP functionality is under testing and the competition status will be announced later over official channels.

--- a/docs/en/slave_api_overview.rst
+++ b/docs/en/slave_api_overview.rst
@@ -15,7 +15,7 @@ The sections below represent typical programming workflow for the slave API whic
 .. _modbus_api_slave_configure_descriptor:
 
 Configuring Slave Data Access
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following functions must be called when the Modbus controller slave port is already initialized. Refer to :ref:`modbus_api_port_initialization`.
 
@@ -74,7 +74,7 @@ The function initializes Modbus communication descriptors for each type of Modbu
 
 At least one area descriptor per each Modbus register type must be set in order to provide register access to its area. If the master tries to access an undefined area, the stack will generate a Modbus exception.
 
-The stack supports the extended data types when enabled through the the option ``CONFIG_FMB_MASTER_TIMEOUT_MS_RESPOND`` in kconfig menu.
+The stack supports the extended data types when enabled through the option ``CONFIG_FMB_EXT_TYPE_SUPPORT`` in kconfig menu.
 In this case the mapped data values can be initialized to specific format using :ref:`modbus_api_endianness_conversion`.
 Please refer to secton :ref:`modbus_mapping_complex_data_types` for more information about data types.
 
@@ -165,7 +165,7 @@ Example to get the actual slave identificator:
 .. _modbus_api_slave_handler_customization:
 
 Slave Customize Function Handlers
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Slave object contains the command handling table to define specific handling functionality for each supported Modbus command. The default handling functions in this table support the most common Modbus commands. However, the list of commands can be extended by adding a new command into the handling table with its custom handling behavior. It is also possible to override the function handler for a specific command. The below described API functions allow using this behavior for Slave objects.
 
@@ -231,7 +231,7 @@ Refer to :ref:`example Serial slave <example_mb_slave>` for more information.
 .. _modbus_api_slave_communication:
 
 Slave Communication
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~
 
 The function below is used to start Modbus controller interface and allows communication.
 
@@ -305,6 +305,8 @@ Example to get event when holding or input registers accessed in the slave:
                     (uint32_t)reg_info.size);
     }
 
+.. note:: Please refer to :ref:`modbus_master_slave_configuration_aspects` for proper configuration.
+
 :cpp:func:`mbc_slave_lock`
 
 :cpp:func:`mbc_slave_unlock`
@@ -331,10 +333,11 @@ The access to registered area shared between several slave objects from user app
     holding_reg_area[2] = 123;
     portEXIT_CRITICAL(&param_lock);
 
+
 .. _modbus_api_slave_destroy:
 
 Modbus Slave Teardown
-^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~
 
 This function stops the Modbus communication stack, destroys the controller interface, and frees all used active objects allocated for the slave.  
 

--- a/modbus/mb_objects/common/mb_types.h
+++ b/modbus/mb_objects/common/mb_types.h
@@ -78,11 +78,7 @@ typedef enum mb_event_enum {
     EV_EXECUTE = 0x0008,                        /*!< Execute function. */
     EV_FRAME_TRANSMIT = 0x0010,                 /*!< Transmission started . */
     EV_FRAME_SENT = 0x0020,                     /*!< Frame sent. */
-    EV_ERROR_PROCESS = 0x0040,                  /*!< Error process state. */
-    EV_MASTER_ERROR_RESPOND_TIMEOUT = 0x0080,   /*!< Request respond timeout. */
-    EV_MASTER_ERROR_RECEIVE_DATA = 0x0100,      /*!< Request receive data error. */
-    EV_MASTER_ERROR_EXECUTE_FUNCTION = 0x0200,  /*!< Request execute function error. */
-    EV_MASTER_PROCESS_SUCCESS = 0x0400          /*!< Master error process. */
+    EV_ERROR_PROCESS = 0x0040                   /*!< Error process state. */
 } mb_event_enum_t;
 
 /*! \ingroup modbus
@@ -109,11 +105,11 @@ typedef mb_exception_t (*mb_fn_handler_fp)(void *, uint8_t *frame_ptr, uint16_t 
  * \brief Error event type
  */
 typedef enum mb_err_event_enum {
-    EV_ERROR_INIT,             /*!< No error, initial state. */
-    EV_ERROR_RESPOND_TIMEOUT,  /*!< Slave respond timeout. */
-    EV_ERROR_RECEIVE_DATA,     /*!< Receive frame data error. */
-    EV_ERROR_EXECUTE_FUNCTION, /*!< Execute function error. */
-    EV_ERROR_OK                /*!< No error, processing completed. */
+    EV_ERROR_INIT,              /*!< No error, initial state. */
+    EV_ERROR_RESPOND_TIMEOUT,   /*!< Slave respond timeout. */
+    EV_ERROR_RECEIVE_DATA,      /*!< Receive frame data error. */
+    EV_ERROR_EXECUTE_FUNCTION,  /*!< Execute function error. */
+    EV_ERROR_OK                 /*!< No error, processing completed. */
 } mb_err_event_t;
 
 typedef struct mb_event_s {
@@ -150,9 +146,9 @@ typedef enum
  */
 typedef enum
 {
-	MB_TMODE_T35,                   /*!< Master receive frame T3.5 timeout. */
-	MB_TMODE_RESPOND_TIMEOUT,       /*!< Master wait respond for slave. */
-	MB_TMODE_CONVERT_DELAY          /*!< Master sent broadcast , then delay sometime.*/
+    MB_TMODE_T35,                   /*!< Master receive frame T3.5 timeout. */
+    MB_TMODE_RESPOND_TIMEOUT,       /*!< Master wait respond for slave. */
+    MB_TMODE_CONVERT_DELAY          /*!< Master sent broadcast , then delay sometime.*/
 } mb_timer_mode_enum_t;
 
 #ifdef __cplusplus

--- a/modbus/mb_objects/mb_master.c
+++ b/modbus/mb_objects/mb_master.c
@@ -497,25 +497,25 @@ static uint8_t mbm_get_dest_addr(mb_base_t *inst)
 
 void mbm_error_cb_respond_timeout(mb_base_t *inst, uint8_t dest_addr, const uint8_t *pdu_data, uint16_t pdu_length)
 {
-    mb_port_event_set_resp_flag(MB_BASE2PORT(inst), EV_MASTER_ERROR_RESPOND_TIMEOUT);
+    mb_port_event_set_resp_flag(MB_BASE2PORT(inst), EV_ERROR_RESPOND_TIMEOUT);
     ESP_LOG_BUFFER_HEX_LEVEL(__func__, (void *)pdu_data, pdu_length, ESP_LOG_DEBUG);
 }
 
 void mbm_error_cb_receive_data(mb_base_t *inst, uint8_t dest_addr, const uint8_t *pdu_data, uint16_t pdu_length)
 {
-    mb_port_event_set_resp_flag(MB_BASE2PORT(inst), EV_MASTER_ERROR_RECEIVE_DATA);
+    mb_port_event_set_resp_flag(MB_BASE2PORT(inst), EV_ERROR_RECEIVE_DATA);
     ESP_LOG_BUFFER_HEX_LEVEL(__func__, (void *)pdu_data, pdu_length, ESP_LOG_DEBUG);
 }
 
 void mbm_error_cb_execute_function(mb_base_t *inst, uint8_t dest_address, const uint8_t *pdu_data, uint16_t pdu_length)
 {
-    mb_port_event_set_resp_flag(MB_BASE2PORT(inst), EV_MASTER_ERROR_EXECUTE_FUNCTION);
+    mb_port_event_set_resp_flag(MB_BASE2PORT(inst), EV_ERROR_EXECUTE_FUNCTION);
     ESP_LOG_BUFFER_HEX_LEVEL(__func__, (void *)pdu_data, pdu_length, ESP_LOG_DEBUG);
 }
 
 void mbm_error_cb_request_success(mb_base_t *inst, uint8_t dest_address, const uint8_t *pdu_data, uint16_t pdu_length)
 {
-    mb_port_event_set_resp_flag(MB_BASE2PORT(inst), EV_MASTER_PROCESS_SUCCESS);
+    mb_port_event_set_resp_flag(MB_BASE2PORT(inst), EV_ERROR_OK);
     ESP_LOG_BUFFER_HEX_LEVEL(__func__, (void *)pdu_data, pdu_length, ESP_LOG_DEBUG);
 }
 
@@ -553,6 +553,8 @@ mb_err_enum_t mbm_poll(mb_base_t *inst)
                     mb_port_event_set_err_type(MB_OBJ(inst->port_obj), EV_ERROR_RESPOND_TIMEOUT);
                     (void)mb_port_event_post(MB_OBJ(inst->port_obj), EVENT(EV_ERROR_PROCESS));
                     ESP_LOGE(TAG, MB_OBJ_FMT", frame send error. %d", MB_OBJ_PARENT(inst), (int)status);
+                } else {
+                    (void)mb_port_event_post(MB_OBJ(inst->port_obj), EVENT(EV_FRAME_SENT));
                 }
                 // Initialize modbus transaction
                 mbm_obj->curr_trans_id = event.trans_id;

--- a/modbus/mb_ports/common/mb_transaction.h
+++ b/modbus/mb_ports/common/mb_transaction.h
@@ -27,13 +27,13 @@ typedef struct transaction_item *transaction_item_handle_t;
 typedef struct transaction_message {
     uint8_t *buffer;
     uint16_t len;
-    int msg_id;
+    uint16_t msg_id;
     int node_id;
     void *pnode;
 } transaction_message_t;
 
 typedef struct transaction_message *transaction_message_handle_t;
-typedef long long transaction_tick_t;
+typedef uint64_t transaction_tick_t;
 
 typedef enum pending_state {
     INIT,
@@ -48,12 +48,14 @@ typedef enum pending_state {
 
 transaction_handle_t transaction_init(void);
 transaction_item_handle_t transaction_enqueue(transaction_handle_t transaction, transaction_message_handle_t message, transaction_tick_t tick);
-transaction_item_handle_t transaction_dequeue(transaction_handle_t transaction, pending_state_t state, transaction_tick_t *tick);
-transaction_item_handle_t transaction_get(transaction_handle_t transaction, int msg_id);
+transaction_item_handle_t transaction_dequeue(transaction_handle_t transaction, pending_state_t pending, transaction_tick_t *tick);
+transaction_item_handle_t transaction_get(transaction_handle_t transaction, uint16_t msg_id);
 transaction_item_handle_t transaction_get_first(transaction_handle_t transaction);
+uint16_t transaction_item_get_id(transaction_item_handle_t item);
 uint8_t *transaction_item_get_data(transaction_item_handle_t item,  size_t *len, uint16_t *msg_id, int *node_id);
-esp_err_t transaction_delete(transaction_handle_t transaction, int msg_id);
+esp_err_t transaction_delete(transaction_handle_t transaction, uint16_t msg_id);
 esp_err_t transaction_delete_item(transaction_handle_t transaction, transaction_item_handle_t item);
+int transaction_delete_by_node_id(transaction_handle_t transaction, int node_id);
 int transaction_delete_expired(transaction_handle_t transaction, transaction_tick_t current_tick, transaction_tick_t timeout);
 
 /**
@@ -61,11 +63,12 @@ int transaction_delete_expired(transaction_handle_t transaction, transaction_tic
  *
  * @return msg id of the deleted message, -1 if no expired message in the transaction
  */
-int transaction_delete_single_expired(transaction_handle_t transaction, transaction_tick_t current_tick, transaction_tick_t timeout);
-esp_err_t transaction_set_state(transaction_handle_t transaction, int msg_id, pending_state_t state);
+uint16_t transaction_delete_single_expired(transaction_handle_t transaction, transaction_tick_t current_tick, transaction_tick_t timeout);
+esp_err_t transaction_set_state(transaction_handle_t transaction, uint16_t msg_id, pending_state_t pending);
 pending_state_t transaction_item_get_state(transaction_item_handle_t item);
 esp_err_t transaction_item_set_state(transaction_item_handle_t item, pending_state_t state);
-esp_err_t transaction_set_tick(transaction_handle_t transaction, int msg_id, transaction_tick_t tick);
+esp_err_t transaction_set_tick(transaction_handle_t transaction, uint16_t msg_id, transaction_tick_t tick);
+transaction_tick_t transaction_item_get_tick(transaction_item_handle_t item);
 uint64_t transaction_get_size(transaction_handle_t transaction);
 void transaction_destroy(transaction_handle_t transaction);
 void transaction_delete_all_items(transaction_handle_t transaction);

--- a/modbus/mb_ports/common/port_common.h
+++ b/modbus/mb_ports/common/port_common.h
@@ -77,10 +77,10 @@ void unlock_obj(_lock_t *lock_ptr);
         spinlock_release(&lock); \
     } while (0)
 
-#define MB_EVENT_REQ_MASK (EventBits_t)(EV_MASTER_PROCESS_SUCCESS |       \
-                                        EV_MASTER_ERROR_RESPOND_TIMEOUT | \
-                                        EV_MASTER_ERROR_RECEIVE_DATA |    \
-                                        EV_MASTER_ERROR_EXECUTE_FUNCTION)
+#define MB_EVENT_REQ_MASK (EventBits_t)(EV_ERROR_OK |       \
+                                        EV_ERROR_RESPOND_TIMEOUT | \
+                                        EV_ERROR_RECEIVE_DATA |    \
+                                        EV_ERROR_EXECUTE_FUNCTION)
 
 #define MB_PORT_CHECK_EVENT(event, mask) (event & mask)
 #define MB_PORT_CLEAR_EVENT(event, mask) \

--- a/modbus/mb_ports/common/port_event.c
+++ b/modbus/mb_ports/common/port_event.c
@@ -144,7 +144,7 @@ bool mb_port_event_res_take(mb_port_base_t *inst, uint32_t timeout)
 {
     MB_RETURN_ON_FALSE((inst && inst->event_obj && inst->event_obj->resource_hdl), false, TAG, 
                             "incorrect object handle.");
-    BaseType_t status = pdTRUE;
+    BaseType_t status = pdFALSE;
     status = xSemaphoreTake(inst->event_obj->resource_hdl, timeout);
     ESP_LOGD(TAG, "%s, mb take resource, (%" PRIu32 " ticks).", inst->descr.parent_name, timeout);
     return (bool)status;
@@ -185,13 +185,13 @@ mb_err_enum_t mb_port_event_wait_req_finish(mb_port_base_t *inst)
             // if we wait for certain event bits but get from poll subset
             ESP_LOGE(TAG, "%s, %s: incorrect event set = 0x%x", inst->descr.parent_name, __func__, (int)rcv_event);
         }
-        if (MB_PORT_CHECK_EVENT(rcv_event, EV_MASTER_PROCESS_SUCCESS)) {
+        if (MB_PORT_CHECK_EVENT(rcv_event, EV_ERROR_OK)) {
             err_status = MB_ENOERR;
-        } else if (MB_PORT_CHECK_EVENT(rcv_event, EV_MASTER_ERROR_RESPOND_TIMEOUT)) {
+        } else if (MB_PORT_CHECK_EVENT(rcv_event, EV_ERROR_RESPOND_TIMEOUT)) {
             err_status = MB_ETIMEDOUT;
-        } else if (MB_PORT_CHECK_EVENT(rcv_event, EV_MASTER_ERROR_RECEIVE_DATA)) {
+        } else if (MB_PORT_CHECK_EVENT(rcv_event, EV_ERROR_RECEIVE_DATA)) {
             err_status = MB_ERECVDATA;
-        } else if (MB_PORT_CHECK_EVENT(rcv_event, EV_MASTER_ERROR_EXECUTE_FUNCTION)) {
+        } else if (MB_PORT_CHECK_EVENT(rcv_event, EV_ERROR_EXECUTE_FUNCTION)) {
             err_status = MB_EILLFUNC;
         }
     } else {

--- a/modbus/mb_ports/common/port_other.c
+++ b/modbus/mb_ports/common/port_other.c
@@ -62,8 +62,12 @@ esp_err_t queue_push(QueueHandle_t queue, void *buf, size_t len, frame_entry_t *
 {
     frame_entry_t frame_info = {0};
 
-    if (!queue) { // || !buf || (len <= 0)
-        return -1;
+    if (!queue) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!uxQueueSpacesAvailable(queue)) {
+        return ESP_ERR_NO_MEM;
     }
 
     if (frame) {

--- a/modbus/mb_ports/common/port_timer.c
+++ b/modbus/mb_ports/common/port_timer.c
@@ -117,7 +117,6 @@ void mb_port_timer_us(mb_port_base_t *inst, uint64_t timeout_us)
     atomic_store(&(inst->timer_obj->timer_state), false);
 }
 
-
 inline void mb_port_set_cur_timer_mode(mb_port_base_t *inst, mb_timer_mode_enum_t tmr_mode)
 {
     atomic_store(&(inst->timer_obj->timer_mode), tmr_mode);

--- a/modbus/mb_ports/serial/port_serial.c
+++ b/modbus/mb_ports/serial/port_serial.c
@@ -331,7 +331,7 @@ bool mb_port_ser_send_data(mb_port_base_t *inst, uint8_t *p_ser_frame, uint16_t 
         count = uart_write_bytes(port_obj->ser_opts.port, p_ser_frame, ser_length);
         // Waits while UART sending the packet
         esp_err_t status = uart_wait_tx_done(port_obj->ser_opts.port, MB_SERIAL_TX_TOUT_TICKS);
-        (void)mb_port_event_post(inst, EVENT(EV_FRAME_SENT));
+
         ESP_LOGD(TAG, "%s, tx buffer sent: (%d) bytes.", inst->descr.parent_name, (int)count);
         MB_RETURN_ON_FALSE((status == ESP_OK), false, TAG, "%s, mb serial sent buffer failure.",
                                 inst->descr.parent_name);

--- a/modbus/mb_ports/tcp/port_tcp_common.h
+++ b/modbus/mb_ports/tcp/port_tcp_common.h
@@ -22,6 +22,7 @@ extern "C" {
 #define MB_FRAME_QUEUE_SZ               (20)
 #define MB_TCP_CHECK_ALIVE_TOUT_MS      (20) // check alive timeout in mS
 #define MB_RECONNECT_TIME_MS            (CONFIG_FMB_TCP_CONNECTION_TOUT_SEC * 1000UL)
+#define MB_TCP_KEEP_ALIVE_TOUT_MS       (CONFIG_FMB_TCP_KEEP_ALIVE_TOUT_SEC * 1000UL)
 #define MB_EVENT_SEND_RCV_TOUT_MS       (500)
 
 #define MB_TCP_MBAP_GET_FIELD(buffer, field) ((uint16_t)((buffer[field] << 8U) | buffer[field + 1]))

--- a/modbus/mb_ports/tcp/port_tcp_driver.c
+++ b/modbus/mb_ports/tcp/port_tcp_driver.c
@@ -302,7 +302,7 @@ int mb_drv_open(void *ctx, mb_uid_info_t addr_info, int flags)
                 goto err;
             }
             if (drv_obj->mb_node_open_count > MB_MAX_FDS) {
-                ESP_LOGD(TAG, "Exceeded maximum node count: %d", drv_obj->mb_node_open_count);
+                ESP_LOGE(TAG, "Exceeded maximum node count: %d", drv_obj->mb_node_open_count);
                 goto err;
             }
             drv_obj->mb_node_open_count++;
@@ -576,7 +576,7 @@ err_t mb_drv_check_node_state(void *ctx, int *fd_ptr, uint32_t timeout_ms)
     pnode = mb_drv_get_next_node_from_set(ctx, fd_ptr, &drv_obj->conn_set);
     if (pnode && FD_ISSET(pnode->sock_id, &drv_obj->conn_set)) {
         uint64_t last_read_div_us = (esp_timer_get_time() - pnode->recv_time);
-        ESP_LOGD(TAG, "%p, node: %d, sock: %d, IP:%s, check connection timeout = %" PRId64 ", rcv_time: %" PRId64 " %" PRId32,
+        ESP_LOGD(TAG, "%p, node: %d, sock: %d, IP:%s, check connection timeout = %" PRId64 ", rcv_time: %" PRId64 " %" PRIu32,
                     ctx, (int)pnode->index, (int)pnode->sock_id, pnode->addr_info.ip_addr_str,
                     (esp_timer_get_time() / 1000), pnode->recv_time / 1000, timeout_ms);
         if (last_read_div_us >= (uint64_t)(timeout_ms * 1000)) {

--- a/modbus/mb_ports/tcp/port_tcp_master.c
+++ b/modbus/mb_ports/tcp/port_tcp_master.c
@@ -453,7 +453,7 @@ MB_EVENT_HANDLER(mbm_on_connect)
                                 ctx, (int)event_info->opt_fd, (int)node_ptr->sock_id, 
                                 node_ptr->addr_info.ip_addr_str);
                     MB_SET_NODE_STATE(node_ptr, MB_SOCK_STATE_CONNECTED);
-                    (void)port_keep_alive(node_ptr->sock_id);
+                    (void)port_keep_alive_enable(node_ptr->sock_id, CONFIG_FMB_TCP_KEEP_ALIVE_TOUT_SEC);
                     ESP_LOGD(TAG, "Opened/connected: %u, %u.",
                                 (unsigned)drv_obj->mb_node_open_count, (unsigned)drv_obj->node_conn_count);
                     if (drv_obj->mb_node_open_count == drv_obj->node_conn_count) {
@@ -595,7 +595,6 @@ MB_EVENT_HANDLER(mbm_on_send_data)
                 info_ptr->tid_counter = (uint16_t)(info_ptr->index << 8U);
             }
         }
-        drv_obj->event_cbs.mb_sync_event_cb(drv_obj->event_cbs.port_arg, MB_SYNC_EVENT_SEND_OK);
         mb_drv_lock(ctx);
         drv_obj->mb_node_curr = info_ptr;
         drv_obj->curr_node_index = info_ptr->index;

--- a/modbus/mb_ports/tcp/port_tcp_utils.h
+++ b/modbus/mb_ports/tcp/port_tcp_utils.h
@@ -92,7 +92,7 @@ int port_enqueue_packet(QueueHandle_t queue, uint8_t *buf, uint16_t len);
 int port_dequeue_packet(QueueHandle_t queue, frame_entry_t* frame_info);
 int port_read_packet(mb_node_info_t* info_ptr);
 err_t port_set_blocking(mb_node_info_t* info_ptr, bool is_blocking);
-int port_keep_alive(int sock);
+int port_keep_alive_enable(int sock, int timeout_sec);
 err_t port_check_alive(mb_node_info_t* info_ptr, uint32_t timeout_ms);
 err_t port_connect(void *ctx, mb_node_info_t* info_ptr);
 bool port_close_connection(mb_node_info_t* info_ptr);

--- a/test_apps/test_common/mb_utest_lib/port_adapter.c
+++ b/test_apps/test_common/mb_utest_lib/port_adapter.c
@@ -616,7 +616,6 @@ bool mb_port_adapter_send_data(mb_port_base_t *inst, uint8_t addrets, uint8_t *f
         (void)mb_port_event_post(inst, EVENT(EV_FRAME_SENT));
         ESP_LOGD(TAG, "%s, tx completed, flags = 0x%04x.", inst->descr.parent_name, (int)flags);
         ret = true;
-        
     }
     else
     {


### PR DESCRIPTION
## Description

This PR contains the simple fix to resolve issue #129 when the Modbus TCP Slave is not able to process requests from multiple Modbus TCP Masters and skips the requests.

## Related

 Fixes #129

## The diagrams to describe the communication aspects of slave and master

### Managing Multiple Connections

The slave can handle multiple masters, but this increases the processing load and can affect response times for all connected masters.

````mermaid
graph TD
    subgraph Modbus TCP Masters
        M1[Master 1]
        M2[Master 2]
        MN[...]
    end

    subgraph Slave [Modbus TCP Slave]
        direction LR
        subgraph CM [Connection Manager - port_tcp_driver class]
            direction TB
            C1[Sock conn 1]
            C2[Sock conn 2]
            CN[Sock conn N]
        end

        subgraph Proc [Processing Logic]
            direction TB
            Q[Request Queue] --> PU{mb_tcp_port - mb_slave}
        end
        
        CM -- Requests --> Q
    end

    M1 --> C1
    M2 --> C2
    MN --> CN

    PU -- Responses --> CM

    style Slave fill:#fdf,stroke:#333,stroke-width:2px
````

### Normal Modbus TCP Communication

This diagram illustrates a successful transaction where the slave processes the request and responds well within the master's timeout period.

````mermaid
sequenceDiagram
    autonumber
    participant Master
    participant Slave

    Master->>Slave: Send Request
    activate Slave
    Note over Slave: Start: Request Processing Time
    Slave-->>Slave: Process Data
    Note over Slave: End: Request Processing Time
    Slave->>Master: Send Response
    deactivate Slave
    Note over Master: Response received within Master Timeout
````

---

### **Race Condition Scenario**

This diagram shows what happens when the slave's processing time is longer than the master's timeout, leading to a race condition.

````mermaid
sequenceDiagram
    autonumber
    participant Master
    participant Slave

    Master->>Slave: Send Request 1
    activate Master
    Note over Master: Start Timer (Master Timeout)
    activate Slave
    Note over Slave: Start: Long Request Processing Time

    %% Master times out while slave is still processing %%
    Note over Master: Master Timeout expires!
    Master-->>Master: Log Timeout Error for Request 1

    Master->>Slave: Send Request 2 (New Transaction)
    deactivate Master

    %% Slave finishes the first request late %%
    Note over Slave: Finish processing Request 1
    Note right of Slave: Slave logs warning and <br/>discards late response for Request 1
    deactivate Slave

    Note over Slave: Receive and start processing Request 2
````

### **Keep-Alive Mechanism**

This mechanism helps the slave detect and close dead connections by sending a probe after a period of inactivity.

````mermaid
sequenceDiagram
    autonumber
    participant Master
    participant Slave

    Note over Slave, Master: Connection is idle...
    Note over Slave: Wait for 'CONFIG_FMB_TCP_KEEP_ALIVE_TOUT_SEC'
    
    Slave->>Master: Send Keep-Alive Probe

    alt Connection is Alive
        Master->>Slave: Respond to Probe (ACK)
        Note over Slave, Master: Connection remains open
    else Connection is Dead
        Note over Master: (No response from Master)
        Note over Slave: Timeout for probe expires
        Slave-->>Slave: Close connection, Log Error "err= -11"
    end
````

## Testing

The  fix allows to wait while previous queued transaction processing is ongoing. This solves the issue when several TCP masters try to request data from the same slave. Tested manually with several (up to four) masters connected to the slave and send the requests every 100ms. The slave was able to process all transactions properly but there are still several aspects to consider.

Testing with multiple Masters connected to one slave and requests at maximum rate is in progress. 
If the Masters send requests too fast with Response Time < Slave Processing time it can cause the overflow of the input queue. The Slave shows the warning that the Master Response time and request rate shall be changed and then skips the response as obsolete. This allows to mitigate the error related to incorrect TID. The fix works just fine when the Masters request rate is limited and maximum response time measured for Slaves is correctly set in the Masters (including possible network delays when the Ethernet is used for other communication in the same network). Measured with 4 Masters connected to one slave. Test time is 4 hours.

Status: Completed

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
