### PR TITLE
incorrect idf version checking syntax (EPROT-34)

### DIFF
--- a/modbus/mb_objects/common/mb_port_types.h
+++ b/modbus/mb_objects/common/mb_port_types.h
@@ -13,7 +13,7 @@
 #endif
 
 // Workaround for atomics incompatibility issue under CPP.
-#if defined(__cplusplus) && (IDF_VERSION <= ESP_IDF_VERSION_VAL(5, 0, 0))
+#if defined(__cplusplus) && (ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(5, 0, 0))
 #include <atomic>
 #define _Atomic(T) std::atomic<T>
 #define atomic_int int


### PR DESCRIPTION
## Description

IDF_VERSION invalidate the atomic compability check in https://github.com/espressif/esp-modbus/blob/914297e2672bbe13d5a602e6c712ec58f6664956/modbus/mb_objects/common/mb_port_types.h#L16
It should be corrected to `ESP_IDF_VERSION`. I consider this as a typo.


The condition was evaluate always false regardless of the IDF version. It may ruin some external libraries also using atomic_int such as `etlcpp`
```
C:/Users/wuyua/Project/UniLAB/projects/project_unilab_drive/managed_components/espressif__esp-modbus/modbus/mb_objects/common/mb_port_types.h:19:20: error: expected nested-name-specifier before 'int'
   19 | #define atomic_int int
      |                    ^~~
C:/Users/wuyua/Project/UniLAB/components/shared/etlcpp/etl/include/etl/atomic/atomic_std.h:64:9: note: in expansion of macro 'atomic_int'
   64 |   using atomic_int            = std::atomic<int>;
      |         ^~~~~~~~~~
```



## Related

https://github.com/espressif/esp-modbus/issues/155

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
