### PR TITLE
fix: Fixed UB dereference because of cast (EPROT-64)

### DIFF
--- a/modbus/mb_ports/tcp/port_tcp_master.c
+++ b/modbus/mb_ports/tcp/port_tcp_master.c
@@ -526,7 +526,8 @@ MB_EVENT_HANDLER(mbm_on_error)
             mb_drv_clear_status_flag(ctx, MB_FLAG_CONNECTED);
             return;
         }
-        int ret = mb_drv_check_node_state(drv_obj, (int *)&event_info->opt_fd, MB_RECONNECT_TIME_MS);
+        int curr_fd = event_info->opt_fd;
+        int ret = mb_drv_check_node_state(drv_obj, &curr_fd, MB_RECONNECT_TIME_MS);
         if ((ret != ERR_OK) && (ret != ERR_TIMEOUT)) {
             node_ptr = mb_drv_get_node(drv_obj, event_info->opt_fd);
             ESP_LOGW(TAG, "%p, "MB_NODE_FMT(", error handling."), ctx, (int)node_ptr->fd,


### PR DESCRIPTION
## Description

`event_info->opt_fd` is of type int16_t however it is referenced and then casted to an int*. The dereference of that int* in `mb_drv_get_next_node_from_set` could (and did) cause undefined behavior. 


When an error has occured, the `mbm_on_error` is called which calls `mb_drv_check_node_state` with a reference of `event_info->opt_fd`, which is a int16_t and gets casted to int*. It internally calls `mb_drv_get_next_node_from_set` where the `fd_ptr` is dereferenced and four bytes are being copied into `fd`. See the outcome below:

```
D (34446) mb_driver: 0x3ffe33c4, fd event get: 0x40:0, |MB_EVENT_ERROR
D (34453) mb_driver: fd_ptr (*fd_ptr): [-720896], (*(int16_t*)fd_ptr) [0]
D (34459) mb_driver: fd:[-720896]
D (34462) mb_driver: fd:[-720895]
D (34465) mb_driver: fd:[-720894]
Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.
```

Within mb_driver I have added a log as test which looks like the following:
```c
ESP_LOGD(TAG, "fd_ptr (*fd_ptr): [%d], (*(int16_t*)fd_ptr) [%d]", *fd_ptr, *(int16_t*)fd_ptr);
```

Currently trying to merge it into bugfix/fix_slave_error_disconnected_node because this can also happen within port_tcp_slave but has been fixed there in https://github.com/espressif/esp-modbus/pull/162. If you want me to instead merge into main, please let me know.

## Related

- https://github.com/espressif/esp-modbus/pull/162

## Testing

It happens for me when a master is connected to a client and the client resets. The log above is shown and the controller crashes with a LoadProhibited. This doesn't happen anymore with the fix. I'm not really sure why we get the MB_EVENT_ERROR but that doesn't really matter.

Might be hard to reproduce because of undefined behavior doing strange things but can be seen as working in the same log but not crashing below:

```
D (22844) mb_driver: 0x3ffe5cf8, fd event get: 0x40:0, |MB_EVENT_ERROR
D (22850) mb_driver: fd_ptr (*fd_ptr): [0], (*(int16_t*)fd_ptr) [0]
D (22855) mb_driver: fd:[0]
D (22858) mb_driver: 0x3ffe5cf8, node: 0, sock: 55, IP:192.168.6.2, check connection timeout = 21968, rcv_time: 11416 2000
```

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
