### PR TITLE
fix: at port_adapter in port_adapter.c (EPROT-68)

### DIFF
--- a/test_apps/test_common/mb_utest_lib/port_adapter.c
+++ b/test_apps/test_common/mb_utest_lib/port_adapter.c
@@ -117,7 +117,10 @@ int mb_port_adapter_get_rx_buffer(mb_port_base_t *inst, uint8_t **frame_ptr, int
     int sz = port_obj->recv_length;
     if (*frame_ptr && *len >= port_obj->recv_length) {
         CRITICAL_SECTION(inst->lock) {
-            memcpy(*frame_ptr, port_obj->rx_buffer, sz);
+            sz = port_obj->recv_length;
+            if (sz > 0 && sz <= *len) {
+                memcpy(*frame_ptr, port_obj->rx_buffer, sz);
+            }
         }
     } else {
         *frame_ptr = port_obj->rx_buffer;
@@ -133,7 +136,10 @@ int mb_port_adapter_get_tx_buffer(mb_port_base_t *inst, uint8_t **frame_ptr, int
     int sz = port_obj->recv_length;
     if (*frame_ptr && *len >= port_obj->recv_length) {
         CRITICAL_SECTION(inst->lock) {
-            memcpy(*frame_ptr, port_obj->rx_buffer, sz);
+            sz = port_obj->recv_length;
+            if (sz > 0 && sz <= *len) {
+                memcpy(*frame_ptr, port_obj->rx_buffer, sz);
+            }
         }
     } else {
         *frame_ptr = port_obj->rx_buffer;


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `test_apps/test_common/mb_utest_lib/port_adapter.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `test_apps/test_common/mb_utest_lib/port_adapter.c:120` |
| **CWE** | CWE-120 |

**Description**: At port_adapter.c lines 120 and 136, memcpy(*frame_ptr, port_obj->rx_buffer, sz) copies sz bytes from the receive buffer into the destination frame pointer. The value of sz is derived from the received Modbus frame length field, which is attacker-controlled. There is no validation that sz does not exceed the allocated size of *frame_ptr before the copy is performed, enabling a heap buffer overflow that corrupts adjacent heap objects.

## Changes
- `test_apps/test_common/mb_utest_lib/port_adapter.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
